### PR TITLE
Add babel-plugin-transform-object-assign as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-core": "^6.0.0",
     "babel-eslint": "^5.0.0",
     "babel-loader": "^6.0.0",
+    "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-react": "^6.0.0",
     "eslint": "^2.0.0",


### PR DESCRIPTION
We've been using `Object.assign` in several places in multiple apps assuming that Babel had a pollyfill but it turns out it only does if you have the plugin installed.  This adds the peer dependency here to ensure all our projects get it installed via their webpack.config files in the query presets section of the babel loader.

@mxenabled/frontend-engineers  
