### PR TITLE
Change no-console to warn instead of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
     "no-array-constructor": 2,
     "no-caller": 2,
     "no-catch-shadow": 0,
-    "no-console": [2, {"allow": ["warn", "error"]}],
+    "no-console": [1, {"allow": ["warn", "error"]}],
     "no-constant-condition": 2,
     "no-continue": 2,
     "no-debugger": 2,


### PR DESCRIPTION
With the change to allow console.warn and console.error, it set the console.log to throw an error instead of a warning.

This sets that from 2 to 1.

@mxenabled/frontend-engineers 
