### PR TITLE
Add responsive methods to ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,12 +179,19 @@ module.exports = {
         'lifecycle',
         'everything-else',
         'rendering',
+        'responsive',
         'style'
       ],
       groups: {
         rendering: [
           '/^render.+$/',
           'render'
+        ],
+        responsive: [
+          'breakpoints',
+          'offsets',
+          'orders',
+          'spans'
         ],
         style: [
           'styles'


### PR DESCRIPTION
This adds responsive methods to the ordering to be used similar to styles.

In the responsive block:
- breakpoints
- offsets
- orders
- spans
