### PR TITLE
Update dependencies for webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mx",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "MX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -21,15 +21,6 @@
   },
   "homepage": "https://github.com/mxenabled/eslint-config-mx#readme",
   "peerDependencies": {
-    "babel-core": "^6.7.4",
-    "babel-eslint": "^6.0.2",
-    "babel-loader": "^6.2.2",
-    "babel-plugin-transform-object-assign": "^6.5.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "eslint": "^2.7.0",
-    "eslint-loader": "^1.3.0",
-    "eslint-plugin-react": "^5.0.0",
-    "webpack": "^1.12.14"
+    "babel-eslint": "^7.2.1"
   }
 }


### PR DESCRIPTION
Simplify dependencies and update babel-eslint to the latest for webpack 2. I tested this locally on the raja webpack 2 branch and it works great 👍 