### PR TITLE
Add missing dependency from prior cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,6 @@ module.exports = {
     "react/no-unknown-property": 2,
     "react/prop-types": [2, { "ignore": ["style", "children", "params"] }],
     "react/react-in-jsx-scope": 2,
-    "react/require-extension": [2, { "extensions": [".js", ".jsx"] }],
     "react/self-closing-comp": 2,
     "react/sort-comp": [2, {
       order: [

--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ module.exports = {
     "react/jsx-closing-bracket-location": 2,
     "react/jsx-space-before-closing": 2,
     "react/jsx-pascal-case": 2,
+    "react/jsx-wrap-multilines": 2,
     "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 0,
@@ -198,7 +199,6 @@ module.exports = {
       }
     }],
     "react/sort-prop-types": [2, {"ignoreCase": true}],
-    "react/wrap-multilines": 2,
     "semi": [2, "always"],
     "semi-spacing": [2, {"before": false, "after": true}],
     "sort-vars": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mx",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "MX's eslint config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mx",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "MX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/mxenabled/eslint-config-mx#readme",
   "peerDependencies": {
+    "eslint-plugin-react": "^6.10.3",
     "babel-eslint": "^7.2.1"
   }
 }


### PR DESCRIPTION
I was overzealous in my previous commit and missed `eslint-plugin-react`. This adds it back in.

I also fixed a couple of deprecation warnings.

@lukeschunk 