### PR TITLE
added jsx-uses-react rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,7 @@ module.exports = {
     "react/jsx-max-props-per-line": [2, {"maximum": 3}],
     "react/jsx-no-undef": 2,
     "react/jsx-sort-props": 2,
+    "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/jsx-closing-bracket-location": 2,
     "react/jsx-space-before-closing": 2,


### PR DESCRIPTION
Adds this rule https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md

Which will allow us to write pure functional components without directly referencing `React` in the file. 