### PR TITLE
allowShortCircuit in no-unused-expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = {
     "no-unexpected-multiline": 2,
     "no-unneeded-ternary": 2,
     "no-unreachable": 2,
-    "no-unused-expressions": 2,
+    "no-unused-expressions": [2, {"allowShortCircuit": true}],
     "no-unused-vars": 2,
     "no-use-before-define": 0,
     "no-var": 2,


### PR DESCRIPTION
I was working today and wanted to do something like this: 
```
if (topLvlcondition) {
  cond1 && bar('hi');
  cond2 && baz('hi again');
}
```

but our linting rule `no-unused-expressions` doesn't allow it. We can use this pattern if we add `allowShortCircuit` - see rule and docs here: http://eslint.org/docs/rules/no-unused-expressions