### PR TITLE
Conflicting block comment fix etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports = {
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/jsx-closing-bracket-location": 2,
-    "react/jsx-space-before-closing": 2,
+    "react/jsx-tag-spacing": [2, {"beforeSelfClosing": "always"}],
     "react/jsx-pascal-case": 2,
     "react/jsx-wrap-multilines": 2,
     "react/no-did-mount-set-state": 0,

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": 2,
     "linebreak-style": 2,
-    "lines-around-comment": [2, {"beforeBlockComment": true, "beforeLineComment": false}],
+    "lines-around-comment": [2, {"allowBlockStart": true, "beforeBlockComment": true, "beforeLineComment": false}],
     "max-nested-callbacks": [2, 3],
     "new-cap": 0,
     "new-parens": 2,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mxenabled/eslint-config-mx#readme",
   "peerDependencies": {
-    "eslint-plugin-react": "^6.10.3",
+    "eslint-plugin-react": "^7.2.1",
     "babel-eslint": "^7.2.1"
   }
 }


### PR DESCRIPTION
This PR does 3 things:
1. Fix conflict with a comment on the first line in a block
2. Fix deprecation warning with `react/jsx-space-before-closing`
3. Upgrade `eslint-plugin-react` to match the `babel-eslint` dependency

Here's an example of the conflict:
```js
() => {
  // my comment
  fn();
}
```
```
error  Expected line before comment  lines-around-comment
```
```js
() => {

  // my comment
  fn();
}
```
```
error  Block must not be padded by blank lines  padded-blocks
```