### PR TITLE
Change operator-linebreak to before instead of after.

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = {
     "object-shorthand": [2, "always"],
     "one-var": [2, "never"],
     "operator-assignment": [2, "always"],
-    "operator-linebreak": [2, "after"],
+    "operator-linebreak": [2, "before"],
     "padded-blocks": [2, "never"],
     "prefer-const": 2,
     "quote-props": 0,


### PR DESCRIPTION
I am proposing that we change our operator line break to either `before` or just turning it off completely.

Current (after):
```js
var fullHeight = borderTop +
                 innerHeight +
                 borderBottom;
```

This PR (before):
```js
var fullHeight = borderTop
               + innerHeight
               + borderBottom;
```
I particularly like `before` *much* better with conditionals and terns:

```js
if (someCondition
    || otherCondition) {
}

answer = everything
  ? 42
  : foo;


answer = everything ? 42
                    : 0
```

As I said before, I would also be okay with removing any before or after rule entirely. I mostly just hate being forced to use after, especially when conditionals and terns are longer and I am using split pane views with more "real life" code examples:

😢  (Sam with after)
```js
const transactions = this.props.displayChildAsParent ?
  TransactionUtils.filterOutParentsOfSplits(this.props.transactions) :
  TransactionUtils.filterOutChildrenOfSplits(this.props.transactions);
```
In this paritcular case, the `? : || &&` characters can get cut off in the current pane, forcing me to horizontally scroll to see what is going on

😄  (Sam with before)
```js
const transactions = this.props.displayChildAsParent
  ? TransactionUtils.filterOutParentsOfSplits(this.props.transactions)
  : TransactionUtils.filterOutChildrenOfSplits(this.props.transactions);
```

With before, the operators are *always* visible and aligned with each other.