### PR TITLE
Enable no-undef

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = {
     "no-this-before-super": 2,
     "no-throw-literal": 2,
     "no-trailing-spaces": 2,
-    "no-undef": 0,
+    "no-undef": 2,
     "no-undef-init": 2,
     "no-undefined": 2,
     "no-underscore-dangle": 0,


### PR DESCRIPTION
This enables `no-undef` https://eslint.org/docs/rules/no-undef

>This rule can help you locate potential ReferenceErrors resulting from misspellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the var keyword in a for loop initializer).

Now that [Glob-based configuration](https://eslint.org/blog/2017/06/eslint-v4.1.0-released) is available with eslint 4.1.0 `"overrides"` and `"globals"` can be used to define allowed globals for tests vs code.

For example, the following could be part of `.eslintrc`:
```json
  "overrides": {
    "files": ["*test.js", "**/__mocks__/*"],
    "globals": {
      "afterAll": true,
      "afterEach": true,
      "beforeAll": true,
      "beforeEach": true,
      "describe": true,
      "expect": true,
      "it": true,
      "jasmine": true,
      "jest": true,
      "spyOn": true
    }
  }
```