### PR TITLE
Jameson/Added darkStyles to sort-comp rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ module.exports = {
         groups: {
           rendering: ["/^render.+$/", "render"],
           responsive: ["breakpoints", "offsets", "orders", "spans"],
-          style: ["styles"]
+          style: ["styles", "darkStyles"]
         }
       }
     ],


### PR DESCRIPTION
This MR adds `darkStyles` to the `react/sort-comp` rule. This will allow a dark styles function after the render which currently results in a lint error.