### PR TITLE
Removing comma-dangle rule, updating README and package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1 / 2020-2-4
+
+- [minor] remove [`comma-dangle`](https://eslint.org/docs/rules/comma-dangle)
+
 # 2.0.0 / 2019-7-15
 
 - [major] change [`react/no-direct-mutation-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md) to error

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = {
     "block-scoped-var": 0,
     "brace-style": 2,
     camelcase: 0,
-    "comma-dangle": 2,
     "comma-spacing": 2,
     "comma-style": 2,
     "computed-property-spacing": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-mx",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mx",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MX's eslint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Removed `comma-dangle` rule as it is in direct opposition to our .prettier formatter rule.
* Updated README
* Incremented version from `2.0.0` to `2.0.1`