### PR TITLE
Disabled no-eq-null rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = {
     "no-else-return": 0,
     "no-empty": 2,
     "no-empty-character-class": 2,
-    "no-eq-null": 2,
+    "no-eq-null": 0,
     "no-eval": 2,
     "no-ex-assign": 2,
     "no-extend-native": 2,


### PR DESCRIPTION
## Proposition 

Remove the no-eq-null rule in eslint: https://eslint.org/docs/rules/no-eq-null

## Rationale
Sometimes you want to check for null *and* undefined in one easy check:

```
value == null
```
With this rule enabled, one has to do:

```
value === null || value === undefined
```

or use a library like Lodash:
```
import _isNil from 'lodash/isNil'

_isNil(value)
```

`isNil` is simply an alias for `==`: https://github.com/lodash/lodash/blob/master/isNil.js

While I share the same concerns as many others about using `==` in javascript generally, I think `== null` is a good exception to that. Remove this rule will not affect other scenarios in which we use `===` over `==`.

## Consequences
Since this is removing a rule, this won't cause any backward incompatible changes to existing projects that use this library.